### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,10 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/matheusdmm/excelula/security/code-scanning/2](https://github.com/matheusdmm/excelula/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimum permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` to allow the workflow to access the repository's contents for building the project.
- `actions: read` to allow the workflow to interact with GitHub Actions artifacts (e.g., downloading dependencies or uploading artifacts).

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
